### PR TITLE
Fix Pkg command for install pacakge from git

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Then, run the Julia application and type, at the prompt
 
 ```using Pkg```
 
-```Pkg.add("https://github.com/SeismicJulia/SeisMain.jl.git")```
+```Pkg.clone("https://github.com/SeismicJulia/SeisMain.jl.git")```
 
 ```using SeisMain```
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Then, run the Julia application and type, at the prompt
 
 ```using Pkg```
 
-```Pkg.clone("https://github.com/SeismicJulia/SeisMain.jl.git")```
+```Pkg.add(PackageSpec("https://github.com/SeismicJulia/SeisMain.jl.git"))```
 
 ```using SeisMain```
 


### PR DESCRIPTION
In original README.md, the command used to install from git is `Pkg.add`, but should be `Pkg.clone`.