### PR TITLE
Moving documenter to docs env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *#~
 *ipynb_checkpoints
 Manifest.toml
+docs/Manifest.toml
 
 # Text files #
 ###################

--- a/Project.toml
+++ b/Project.toml
@@ -6,16 +6,12 @@ version = "0.1.3"
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Documenter = "1"
-DocumenterTools = "0.1"
 DataFrames = "1"
 julia = "1"
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,6 +2,3 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
 SeisMain = "5696fd22-15e8-11e9-1986-f9ab08703604"
-
-[compat]
-DocumenterTools = "0.1.2"


### PR DESCRIPTION
Normally, in packages, it is better to have the documentation-related packages in the docs environment so as not to constrain the versions the user might be using.